### PR TITLE
Bugfix: Remove empty directories recursively and do not remove top level directory.

### DIFF
--- a/uploader/views/tool_views.py
+++ b/uploader/views/tool_views.py
@@ -78,7 +78,7 @@ def rename(request,*args,**kwargs):
         new_path = os.path.normpath(new_path)
 
         # check for badness
-        assert new_path.startswith(arrivals_dir)
+        assert new_path.startswith(os.path.join(arrivals_dir, stream))
 
         os.rename(old_path, new_path)
 

--- a/uploader/views/tool_views.py
+++ b/uploader/views/tool_views.py
@@ -224,7 +224,9 @@ def fix_empty(request,*args,**kwargs):
 
     # make fix function
     def _fix_empty(start_dir):
-        for directory, dirs, files in os.walk(start_dir):
+        for directory, dirs, files in os.walk(start_dir, topdown=False):
+            if directory == start_dir:
+                pass
             if len(dirs) == 0 and len(files) == 0:
                 print("Removing Empty directory")
                 os.rmdir(directory)

--- a/uploader/views/tool_views.py
+++ b/uploader/views/tool_views.py
@@ -220,7 +220,8 @@ def fix_zero(request,*args,**kwargs):
 
 
 def fix_empty(request,*args,**kwargs):
-    """Apply a fix to remove empty directories"""
+    """Apply a fix to remove empty directories - including directories that contain only other empty directories.
+    Does not remove the top level directory."""
 
     # make fix function
     def _fix_empty(start_dir):

--- a/uploader/views/tool_views.py
+++ b/uploader/views/tool_views.py
@@ -225,11 +225,11 @@ def fix_empty(request,*args,**kwargs):
 
     # make fix function
     def _fix_empty(start_dir):
-        for directory, dirs, files in os.walk(start_dir, topdown=False):
-            if directory == start_dir:
-                pass
-            if len(dirs) == 0 and len(files) == 0:
-                print("Removing Empty directory")
+        for directory, _, files in os.walk(start_dir, topdown=False):
+            if directory == start_dir:  # Never remove the top level directory
+                continue
+            if len(os.listdir(directory)) == 0 and len(files) == 0:
+                print(f"Removing Empty directory {directory}")
                 os.rmdir(directory)
 
     return fix(request, "fix_empty_dir", """Remove any empty directories.""", _fix_empty,**kwargs)


### PR DESCRIPTION
The tool to remove empty directories in a delivery/stream did not behave as expected. The changes made in this PR mean that the "remove empty dirs" tool (`fix_empty`) will:
- remove all empty directories
- remove all directories which only contain empty directories (directly or indirectly)
- prevent users from irreversibly removing the top directory of a stream

Additionally, testing the renaming tool I found that users can rename files out of the stream using `../` (but importantly not out of their user path). The changes made in this PR mean that the "rename file" (`rename`) tool will:
- prevent users from indirectly move files out of the current stream